### PR TITLE
Add new part icons to acquisition table

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1360,5 +1360,65 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 			return part.getRepairPartType();
 		}
 	}
+
+	public static String findPartImage(Part part) {
+		String imgPath = null;
+        int repairType = Part.findCorrectRepairType(part);
+        
+        switch (repairType) {
+        	case Part.REPAIR_PART_TYPE.ARMOR:
+        		imgPath = "data/images/misc/repair/armor.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.AMMO:
+        		imgPath = "data/images/misc/repair/ammo.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.ACTUATOR:
+        		imgPath = "data/images/misc/repair/actuator.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.ENGINE:
+        		imgPath = "data/images/misc/repair/engine.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.ELECTRONICS:
+        		imgPath = "data/images/misc/repair/electronics.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.HEATSINK:
+        		imgPath = "data/images/misc/repair/heatsink.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.WEAPON:
+        		EquipmentType equipmentType = null;
+        		
+        		if (part instanceof EquipmentPart) {
+        			equipmentType = ((EquipmentPart)part).getType();
+        		} else if (part instanceof MissingEquipmentPart) {
+        			equipmentType = ((MissingEquipmentPart)part).getType();
+        		}
+
+        		if (null != equipmentType) {
+	        		if (equipmentType.hasFlag(WeaponType.F_LASER)) {
+	        			imgPath = "data/images/misc/repair/laser.png";	
+	        		} else if (equipmentType.hasFlag(WeaponType.F_MISSILE)) {
+	        			imgPath = "data/images/misc/repair/missile.png";	
+	        		} else if (equipmentType.hasFlag(WeaponType.F_BALLISTIC)) {
+	        			imgPath = "data/images/misc/repair/ballistic.png";	
+	        		} else if (equipmentType.hasFlag(WeaponType.F_ARTILLERY)) {
+	        			imgPath = "data/images/misc/repair/artillery.png";	
+	        		}	        		
+        		}
+        		
+        		break;
+        	case Part.REPAIR_PART_TYPE.MEK_LOCATION:
+        		imgPath = "data/images/misc/repair/location_mek.png";
+        		break;
+        	case Part.REPAIR_PART_TYPE.PHYSICAL_WEAPON:
+        		imgPath = "data/images/misc/repair/melee.png";
+        		break;
+        }
+
+        if (null == imgPath) {
+        	imgPath = "data/images/misc/repair/equipment.png";
+        }
+        
+        return imgPath;
+	}
 }
 

--- a/MekHQ/src/mekhq/gui/model/AcquisitionTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/AcquisitionTableModel.java
@@ -9,6 +9,7 @@ import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
 import mekhq.IconPackage;
+import mekhq.campaign.parts.Part;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.BasicInfo;
 
@@ -46,8 +47,19 @@ public class AcquisitionTableModel extends DataTableModel {
                 Object value, boolean isSelected, boolean hasFocus,
                 int row, int column) {
             Component c = this;
+            int actualRow = table.convertRowIndexToModel(row);
             //MissingPart task = getAcquisitionAt(row);
-            Image imgTool = getToolkit().getImage("data/images/misc/tools.png"); //$NON-NLS-1$
+            
+            IAcquisitionWork aw = getAcquisitionAt(actualRow);
+            String imgPath = "";
+            
+            if (aw instanceof Part) {
+            	imgPath = Part.findPartImage((Part)aw);
+            } else {
+            	imgPath = "data/images/misc/repair/equipment.png";
+            }
+            
+            Image imgTool = getToolkit().getImage(imgPath); //$NON-NLS-1$
             this.setImage(imgTool);
             setOpaque(true);
             setText(getValueAt(row, column).toString(), "black");

--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -7,12 +7,8 @@ import java.util.ArrayList;
 import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
-import megamek.common.EquipmentType;
-import megamek.common.WeaponType;
 import mekhq.IconPackage;
 import mekhq.campaign.parts.Part;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.gui.BasicInfo;
 
 /**
@@ -63,64 +59,7 @@ public class TaskTableModel extends DataTableModel {
             int actualRow = table.convertRowIndexToModel(row);
             
             Part part = getTaskAt(actualRow);
-            String imgPath = null;
-
-            int repairType = Part.findCorrectRepairType(part);
-            
-            switch (repairType) {
-	        	case Part.REPAIR_PART_TYPE.ARMOR:
-	        		imgPath = "data/images/misc/repair/armor.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.AMMO:
-	        		imgPath = "data/images/misc/repair/ammo.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.ACTUATOR:
-	        		imgPath = "data/images/misc/repair/actuator.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.ENGINE:
-	        		imgPath = "data/images/misc/repair/engine.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.ELECTRONICS:
-	        		imgPath = "data/images/misc/repair/electronics.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.HEATSINK:
-	        		imgPath = "data/images/misc/repair/heatsink.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.WEAPON:
-	        		EquipmentType equipmentType = null;
-	        		
-	        		if (part instanceof EquipmentPart) {
-	        			equipmentType = ((EquipmentPart)part).getType();
-	        		} else if (part instanceof MissingEquipmentPart) {
-	        			equipmentType = ((MissingEquipmentPart)part).getType();
-	        		}
-
-	        		if (null != equipmentType) {
-		        		if (equipmentType.hasFlag(WeaponType.F_LASER)) {
-		        			imgPath = "data/images/misc/repair/laser.png";	
-		        		} else if (equipmentType.hasFlag(WeaponType.F_MISSILE)) {
-		        			imgPath = "data/images/misc/repair/missile.png";	
-		        		} else if (equipmentType.hasFlag(WeaponType.F_BALLISTIC)) {
-		        			imgPath = "data/images/misc/repair/ballistic.png";	
-		        		} else if (equipmentType.hasFlag(WeaponType.F_ARTILLERY)) {
-		        			imgPath = "data/images/misc/repair/artillery.png";	
-		        		}	        		
-	        		}
-	        		
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.MEK_LOCATION:
-	        		imgPath = "data/images/misc/repair/location_mek.png";
-	        		break;
-	        	case Part.REPAIR_PART_TYPE.PHYSICAL_WEAPON:
-	        		imgPath = "data/images/misc/repair/melee.png";
-	        		break;
-            }
-
-            if (null == imgPath) {
-            	imgPath = "data/images/misc/repair/equipment.png";
-            }
-            
-            Image imgTool = getToolkit().getImage(imgPath); //$NON-NLS-1$
+            Image imgTool = getToolkit().getImage(Part.findPartImage(part)); //$NON-NLS-1$
             
             this.setImage(imgTool);
             setOpaque(true);


### PR DESCRIPTION
I extracted the new part icon code from the TaskTableModel and put it directly in Part as a static method. This allows us to apply the same
iconification to the acquisition table as well as the repair task table which will keep them visually insync.
